### PR TITLE
Fix/dashboard sidebar loading to fetch role and Fix permission to access the history page

### DIFF
--- a/components/dashboard-sidebar.tsx
+++ b/components/dashboard-sidebar.tsx
@@ -9,13 +9,16 @@ export default function DashboardSidebar() {
   const pathname = usePathname();
   const supabase = createClient();
   const [role,setRole] = useState<"user" | "admin" | null>(null)
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const fetchRole = async() => {
       try{
-        const { data: sessionData } = await supabase.auth.getUser();
-        const user = sessionData?.user;
-        if(!user) return;
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) {
+          setLoading(false);
+          return;
+        }
 
         const {data : row,error} =await supabase
           .from("user_info")
@@ -29,10 +32,19 @@ export default function DashboardSidebar() {
       }catch(error){
         console.log(error);
         console.log("โหลดroleไม่สำเร็จ");
+      } finally {
+        setLoading(false);
       }
     };
     fetchRole();
   }, [supabase]);
+  if (loading || role === null) {
+  return (
+    <aside className="w-max bg-white border-r p-4 md:w-[300px]">
+      {/* เว้นว่างไว้ให้ skeleton หรือเปล่า ๆ */}
+    </aside>
+  );
+}
 
   const userMenu = [
     { href: "/dashboard", label: "แดชบอร์ด", icon: <LayoutDashboard size={18} /> },


### PR DESCRIPTION
1.Edit dashboard sidebar by add loading state to show a correct sidebar for each role
<img width="2852" height="1512" alt="Screenshot 2025-09-13 112150" src="https://github.com/user-attachments/assets/4c7d808d-5ca5-40e5-946c-13912c032447" />


2.Edit History Page - access was allowed only to admins. if login with user account and go to /dashboard/history it will push to auth/login

Discord : Ch